### PR TITLE
Add V5 talk link to companion website

### DIFF
--- a/2026/ABAPConf 2026/V5 - Back to ABAP - How Vibe Coding Brought a Lapsed Developer Back to Life.md
+++ b/2026/ABAPConf 2026/V5 - Back to ABAP - How Vibe Coding Brought a Lapsed Developer Back to Life.md
@@ -1,0 +1,5 @@
+# V5 – Back to ABAP: How Vibe Coding Brought a Lapsed Developer Back to Life
+
+ABAPConf 2026 session.
+
+🔗 **Presentation & companion website:** https://hobru.github.io/abapconf-2026/


### PR DESCRIPTION
Adds a Markdown link file for my ABAPConf 2026 session **V5 – Back to ABAP: How Vibe Coding Brought a Lapsed Developer Back to Life**, pointing to the companion website: https://hobru.github.io/abapconf-2026/